### PR TITLE
Enable Windows builds in GitHub workflows and remove deprecated Ports

### DIFF
--- a/.github/workflows/build-dev-branches.yml
+++ b/.github/workflows/build-dev-branches.yml
@@ -24,19 +24,26 @@ jobs:
         run: |
           ./gradlew clean build --stacktrace --scan --console=plain --no-daemon
 
-# TODO: Re-enable once Process based Jaeger server in test cases are fixed
-#  windows-build:
-#    runs-on: windows-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v1
-#        with:
-#          java-version: 11
-#      - name: Grant execute permission for gradlew
-#        run: chmod +x gradlew
-#      - name: Build with Gradle
-#        env:
-#          packageUser: ${{ github.actor }}
-#          packagePAT: ${{ secrets.GITHUB_TOKEN }}
-#        run: ./gradlew.bat clean build --stacktrace --scan --console=plain --no-daemon
+  windows-build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Download Jaeger server executable
+        env:
+          JAEGER_VERSION: 1.18.0
+        run: |
+          Invoke-WebRequest https://github.com/jaegertracing/jaeger/releases/download/v$env:JAEGER_VERSION/jaeger-$env:JAEGER_VERSION-windows-amd64.tar.gz -O jaeger.tar.gz
+          tar -xzvf jaeger.tar.gz
+          mv jaeger-$env:JAEGER_VERSION-windows-amd64 jaeger
+          echo "JAEGER_SERVER_EXECUTABLE=$(Resolve-Path jaeger\jaeger-all-in-one.exe)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Build with Gradle
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew.bat clean build --stacktrace --scan --console=plain --no-daemon

--- a/.github/workflows/build-dev-branches.yml
+++ b/.github/workflows/build-dev-branches.yml
@@ -36,7 +36,7 @@ jobs:
         run: chmod +x gradlew
       - name: Download Jaeger server executable
         env:
-          JAEGER_VERSION: 1.18.0
+          JAEGER_VERSION: 1.21.0
         run: |
           Invoke-WebRequest https://github.com/jaegertracing/jaeger/releases/download/v$env:JAEGER_VERSION/jaeger-$env:JAEGER_VERSION-windows-amd64.tar.gz -O jaeger.tar.gz
           tar -xzvf jaeger.tar.gz

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -37,7 +37,7 @@ jobs:
         run: chmod +x gradlew
       - name: Download Jaeger server executable
         env:
-          JAEGER_VERSION: 1.18.0
+          JAEGER_VERSION: 1.21.0
         run: |
           Invoke-WebRequest https://github.com/jaegertracing/jaeger/releases/download/v$env:JAEGER_VERSION/jaeger-$env:JAEGER_VERSION-windows-amd64.tar.gz -O jaeger.tar.gz
           tar -xzvf jaeger.tar.gz

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -24,28 +24,27 @@ jobs:
           packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: ./gradlew clean build --stacktrace --scan --console=plain --no-daemon
 
-# TODO: Re-enable once Process based Jaeger server in test cases are fixed
-#  windows-build:
-#    runs-on: windows-latest
-#    if: github.repository_owner == 'ballerina-platform'
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v1
-#        with:
-#          java-version: 11
-#      - name: Grant execute permission for gradlew
-#        run: chmod +x gradlew
-#      - name: Download Jaeger server executable
-#        env:
-#          JAEGER_VERSION: 1.18.0
-#        run: |
-#          Invoke-WebRequest https://github.com/jaegertracing/jaeger/releases/download/v$env:JAEGER_VERSION/jaeger-$env:JAEGER_VERSION-windows-amd64.tar.gz -O jaeger.tar.gz
-#          tar -xzvf jaeger.tar.gz
-#          mv jaeger-$env:JAEGER_VERSION-windows-amd64 jaeger
-#          echo "JAEGER_SERVER_EXECUTABLE=$(Resolve-Path jaeger\jaeger-all-in-one.exe)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-#      - name: Build with Gradle
-#        env:
-#          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-#          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
-#        run: ./gradlew.bat clean build --stacktrace --scan --console=plain --no-daemon
+  windows-build:
+    runs-on: windows-latest
+    if: github.repository_owner == 'ballerina-platform'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Download Jaeger server executable
+        env:
+          JAEGER_VERSION: 1.18.0
+        run: |
+          Invoke-WebRequest https://github.com/jaegertracing/jaeger/releases/download/v$env:JAEGER_VERSION/jaeger-$env:JAEGER_VERSION-windows-amd64.tar.gz -O jaeger.tar.gz
+          tar -xzvf jaeger.tar.gz
+          mv jaeger-$env:JAEGER_VERSION-windows-amd64 jaeger
+          echo "JAEGER_SERVER_EXECUTABLE=$(Resolve-Path jaeger\jaeger-all-in-one.exe)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Build with Gradle
+        env:
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: ./gradlew.bat clean build --stacktrace --scan --console=plain --no-daemon

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,27 +21,26 @@ jobs:
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew clean build --stacktrace --scan --console=plain --no-daemon
 
-# TODO: Re-enable once Process based Jaeger server in test cases are fixed
-#  windows-build:
-#    runs-on: windows-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v1
-#        with:
-#          java-version: 11
-#      - name: Grant execute permission for gradlew
-#        run: chmod +x gradlew
-#      - name: Download Jaeger server executable
-#        env:
-#          JAEGER_VERSION: 1.18.0
-#        run: |
-#          Invoke-WebRequest https://github.com/jaegertracing/jaeger/releases/download/v$env:JAEGER_VERSION/jaeger-$env:JAEGER_VERSION-windows-amd64.tar.gz -O jaeger.tar.gz
-#          tar -xzvf jaeger.tar.gz
-#          mv jaeger-$env:JAEGER_VERSION-windows-amd64 jaeger
-#          echo "JAEGER_SERVER_EXECUTABLE=$(Resolve-Path jaeger\jaeger-all-in-one.exe)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-#      - name: Build with Gradle
-#        env:
-#          packageUser: ${{ github.actor }}
-#          packagePAT: ${{ secrets.GITHUB_TOKEN }}
-#        run: ./gradlew.bat clean build --stacktrace --scan --console=plain --no-daemon
+  windows-build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Download Jaeger server executable
+        env:
+          JAEGER_VERSION: 1.18.0
+        run: |
+          Invoke-WebRequest https://github.com/jaegertracing/jaeger/releases/download/v$env:JAEGER_VERSION/jaeger-$env:JAEGER_VERSION-windows-amd64.tar.gz -O jaeger.tar.gz
+          tar -xzvf jaeger.tar.gz
+          mv jaeger-$env:JAEGER_VERSION-windows-amd64 jaeger
+          echo "JAEGER_SERVER_EXECUTABLE=$(Resolve-Path jaeger\jaeger-all-in-one.exe)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Build with Gradle
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew.bat clean build --stacktrace --scan --console=plain --no-daemon

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,7 +33,7 @@ jobs:
         run: chmod +x gradlew
       - name: Download Jaeger server executable
         env:
-          JAEGER_VERSION: 1.18.0
+          JAEGER_VERSION: 1.21.0
         run: |
           Invoke-WebRequest https://github.com/jaegertracing/jaeger/releases/download/v$env:JAEGER_VERSION/jaeger-$env:JAEGER_VERSION-windows-amd64.tar.gz -O jaeger.tar.gz
           tar -xzvf jaeger.tar.gz

--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ allprojects {
             }
         }
         maven {
-            url 'https://maven.pkg.github.com/ballerina-platform/module-ballerina-runtime'
+            url 'https://maven.pkg.github.com/ballerina-platform/module-ballerina-reflect'
             credentials {
                 username System.getenv("packageUser")
                 password System.getenv("packagePAT")
@@ -201,7 +201,7 @@ subprojects {
 
         // Standard Library Transitive Dependencies
         ballerinaStdLibs "org.ballerinalang:io-ballerina:${stdlibIoVersion}"
-        ballerinaStdLibs "org.ballerinalang:runtime-ballerina:${stdlibRuntimeVersion}"
+        ballerinaStdLibs "org.ballerinalang:reflect-ballerina:${stdlibReflectVersion}"
         ballerinaStdLibs "org.ballerinalang:os-ballerina:${stdlibOsVersion}"
         ballerinaStdLibs "org.ballerinalang:time-ballerina:${stdlibTimeVersion}"
         ballerinaStdLibs "org.ballerinalang:task-ballerina:${stdlibTaskVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,6 @@ okIoVersion=2.2.2
 stdlibHttpVersion=1.0.5-SNAPSHOT
 stdlibIoVersion=0.5.5-SNAPSHOT
 stdlibRegexVersion=0.6.0-SNAPSHOT
-stdlibRuntimeVersion=0.5.5-SNAPSHOT
 stdlibOsVersion=0.7.0-SNAPSHOT
 stdlibTimeVersion=1.0.6-SNAPSHOT
 stdlibTaskVersion=1.1.5-SNAPSHOT
@@ -46,6 +45,7 @@ stdlibJwtVersion=1.0.7-SNAPSHOT
 stdlibOAuth2Version=1.0.5-SNAPSHOT
 stdlibUuidVersion=0.9.1-SNAPSHOT
 stdlibEncodingVersion=1.0.7-SNAPSHOT
+stdlibReflectVersion=0.5.5-SNAPSHOT
 
 # Test Dependency Versions
 testngVersion=6.14.3

--- a/jaeger-extension-native/src/main/java/io/ballerina/observe/trace/jaeger/Constants.java
+++ b/jaeger-extension-native/src/main/java/io/ballerina/observe/trace/jaeger/Constants.java
@@ -40,7 +40,7 @@ public class Constants {
     static final String DEFAULT_SAMPLER_TYPE = "const";
     static final int DEFAULT_SAMPLER_PARAM = 1;
     static final String DEFAULT_REPORTER_HOSTNAME = "localhost";
-    static final int DEFAULT_REPORTER_PORT = 5775;
+    static final int DEFAULT_REPORTER_PORT = 6831;
     static final int DEFAULT_REPORTER_FLUSH_INTERVAL = 1000;
     static final int DEFAULT_REPORTER_MAX_BUFFER_SPANS = 10000;
 }

--- a/jaeger-extension-native/src/main/java/io/ballerina/observe/trace/jaeger/Constants.java
+++ b/jaeger-extension-native/src/main/java/io/ballerina/observe/trace/jaeger/Constants.java
@@ -29,18 +29,30 @@ public class Constants {
 
     static final String TRACER_NAME = "jaeger";
 
+    /*
+     * Configuration Keys.
+     */
+
     private static final String JAEGER_CONFIG_TABLE = CONFIG_TABLE_TRACING + ".jaeger";
     static final String SAMPLER_TYPE_CONFIG = JAEGER_CONFIG_TABLE + ".sampler.type";
     static final String SAMPLER_PARAM_CONFIG = JAEGER_CONFIG_TABLE + ".sampler.param";
-    static final String REPORTER_HOST_NAME_CONFIG = JAEGER_CONFIG_TABLE + ".reporter.hostname";
-    static final String REPORTER_PORT_CONFIG = JAEGER_CONFIG_TABLE + ".reporter.port";
+
     static final String REPORTER_FLUSH_INTERVAL_MS_CONFIG = JAEGER_CONFIG_TABLE + ".reporter.flush.interval.ms";
     static final String REPORTER_MAX_BUFFER_SPANS_CONFIG = JAEGER_CONFIG_TABLE + ".reporter.max.buffer.spans";
 
+    static final String REPORTER_AGENT_HOSTNAME_CONFIG = JAEGER_CONFIG_TABLE + ".reporter.agent.hostname";
+    static final String REPORTER_AGENT_PORT_CONFIG = JAEGER_CONFIG_TABLE + ".reporter.agent.port";
+
+    /*
+     * Configuration Default Values.
+     */
+
     static final String DEFAULT_SAMPLER_TYPE = "const";
     static final int DEFAULT_SAMPLER_PARAM = 1;
-    static final String DEFAULT_REPORTER_HOSTNAME = "localhost";
-    static final int DEFAULT_REPORTER_PORT = 6831;
+
     static final int DEFAULT_REPORTER_FLUSH_INTERVAL = 1000;
     static final int DEFAULT_REPORTER_MAX_BUFFER_SPANS = 10000;
+
+    static final String DEFAULT_REPORTER_AGENT_HOSTNAME = "localhost";
+    static final int DEFAULT_REPORTER_AGENT_PORT = 6831;
 }

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/JaegerTracesTestCase.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/JaegerTracesTestCase.java
@@ -49,6 +49,7 @@ import java.util.stream.Collectors;
 
 import static io.ballerina.runtime.observability.ObservabilityConstants.CONFIG_TABLE_TRACING;
 import static io.ballerina.runtime.observability.ObservabilityConstants.CONFIG_TRACING_ENABLED;
+import static io.ballerina.runtime.observability.ObservabilityConstants.UNKNOWN_SERVICE;
 
 /**
  * Integration test for Jaeger extension.
@@ -79,8 +80,8 @@ public class JaegerTracesTestCase extends BaseTestCase {
     public Object[][] getTestJaegerMetricsData() {
         final String jaegerConfTable = "--b7a.observability.tracing.jaeger";
         return new Object[][]{
-                {"localhost", 6831, JaegerServerProtocol.JAEGER_COMPACT_THRIFT, new String[0]},
-                {"127.0.0.1", 6831, JaegerServerProtocol.JAEGER_COMPACT_THRIFT, new String[]{
+                {"localhost", 6831, JaegerServerProtocol.UDP_COMPACT_THRIFT, new String[0]},
+                {"127.0.0.1", 6831, JaegerServerProtocol.UDP_COMPACT_THRIFT, new String[]{
                         jaegerConfTable + ".reporter.hostname=127.0.0.1", jaegerConfTable + ".reporter.port=6831"}}
         };
     }
@@ -129,8 +130,9 @@ public class JaegerTracesTestCase extends BaseTestCase {
 
         List<String> servicesQueryResponseData = servicesQueryResponse.getData();
         Assert.assertNotNull(servicesQueryResponseData);
-        Assert.assertEquals(servicesQueryResponseData.size(), 1);
-        Assert.assertEquals(servicesQueryResponseData.get(0), SAMPLE_SERVER_NAME);
+        Assert.assertEquals(servicesQueryResponseData.size(), 2);
+        Assert.assertEquals(new HashSet<>(servicesQueryResponseData),
+                new HashSet<>(Arrays.asList(SAMPLE_SERVER_NAME, UNKNOWN_SERVICE)));
 
         // Read traces from Jaeger query endpoint
         HttpResponse tracesQueryHttpResponse = HttpClientRequest.doGet("http://localhost:16686/api/traces?end="
@@ -149,9 +151,9 @@ public class JaegerTracesTestCase extends BaseTestCase {
         Assert.assertEquals(jaegerTrace.getSpans().size(), 3);
         Assert.assertEquals(jaegerTrace.getProcesses().size(), 1);
 
-        String span1Position = "01_http_svc_test.bal:21:5";
-        JaegerSpan span1 = findSpan(jaegerTrace, "01_http_svc_test.bal:21:5");
-        Assert.assertNotNull(span1);
+        String span1Position = "01_http_svc_test.bal:22:5";
+        JaegerSpan span1 = findSpan(jaegerTrace, span1Position);
+        Assert.assertNotNull(span1, "Span from position " + span1Position + " not found");
         Assert.assertEquals(span1.getOperationName(), "get /sum");
         Assert.assertEquals(span1.getReferences().size(), 0);
         Assert.assertEquals(span1.getProcessID(), JAEGER_PROCESS_ID);
@@ -168,19 +170,19 @@ public class JaegerTracesTestCase extends BaseTestCase {
                 new JaegerTag("sampler.param", "bool", "true"),
                 new JaegerTag("http.url", "string", "/test/sum"),
                 new JaegerTag("src.resource.accessor", "string", "get"),
-                new JaegerTag("entrypoint.function.position", "string", "01_http_svc_test.bal:21:5"),
+                new JaegerTag("entrypoint.function.position", "string", span1Position),
                 new JaegerTag("protocol", "string", "http"),
                 new JaegerTag("src.service.resource", "string", "true"),
                 new JaegerTag("span.kind", "string", "server"),
-                new JaegerTag("src.position", "string", "01_http_svc_test.bal:21:5"),
+                new JaegerTag("src.position", "string", span1Position),
                 new JaegerTag("src.resource.path", "string", "/sum"),
                 new JaegerTag("http.method", "string", "GET"),
                 new JaegerTag("internal.span.format", "string", "proto")
         )));
 
-        String span2Position = "01_http_svc_test.bal:23:19";
+        String span2Position = "01_http_svc_test.bal:24:19";
         JaegerSpan span2 = findSpan(jaegerTrace, span2Position);
-        Assert.assertNotNull(span2);
+        Assert.assertNotNull(span2, "Span from position " + span2Position + " not found");
         Assert.assertEquals(span2.getOperationName(), "$anon/./ObservableAdder:getSum");
         Assert.assertEquals(span2.getReferences().size(), 1);
         Assert.assertEquals(span2.getReferences().get(0).getRefType(), "CHILD_OF");
@@ -192,19 +194,19 @@ public class JaegerTracesTestCase extends BaseTestCase {
         Assert.assertTrue(span2.getDuration() < endTimeMicroseconds - startTimeMicroseconds,
                 "span with position ID \"" + span2Position + "\" duration not between start and end time");
         Assert.assertEquals(span2.getTags(), new HashSet<>(Arrays.asList(
-                new JaegerTag("entrypoint.function.position", "string", "01_http_svc_test.bal:21:5"),
+                new JaegerTag("entrypoint.function.position", "string", span1Position),
                 new JaegerTag("src.module", "string", "$anon/.:0.0.0"),
                 new JaegerTag("span.kind", "string", "client"),
                 new JaegerTag("src.object.name", "string", "$anon/./ObservableAdder"),
                 new JaegerTag("entrypoint.function.module", "string", "$anon/.:0.0.0"),
-                new JaegerTag("src.position", "string", "01_http_svc_test.bal:23:19"),
+                new JaegerTag("src.position", "string", span2Position),
                 new JaegerTag("src.function.name", "string", "getSum"),
                 new JaegerTag("internal.span.format", "string", "proto")
         )));
 
-        String span3Position = "01_http_svc_test.bal:27:20";
+        String span3Position = "01_http_svc_test.bal:28:20";
         JaegerSpan span3 = findSpan(jaegerTrace, span3Position);
-        Assert.assertNotNull(span3);
+        Assert.assertNotNull(span3, "Span from position " + span3Position + " not found");
         Assert.assertEquals(span3.getOperationName(), "ballerina/http/Caller:respond");
         Assert.assertEquals(span3.getReferences().size(), 1);
         Assert.assertEquals(span3.getReferences().get(0).getRefType(), "CHILD_OF");
@@ -217,12 +219,12 @@ public class JaegerTracesTestCase extends BaseTestCase {
                 "span with position ID \"" + span3Position + "\" duration not between start and end time");
         Assert.assertEquals(span3.getTags(), new HashSet<>(Arrays.asList(
                 new JaegerTag("http.status_code", "string", "200"),
-                new JaegerTag("entrypoint.function.position", "string", "01_http_svc_test.bal:21:5"),
+                new JaegerTag("entrypoint.function.position", "string", span1Position),
                 new JaegerTag("src.module", "string", "$anon/.:0.0.0"),
                 new JaegerTag("span.kind", "string", "client"),
                 new JaegerTag("src.object.name", "string", "ballerina/http/Caller"),
                 new JaegerTag("entrypoint.function.module", "string", "$anon/.:0.0.0"),
-                new JaegerTag("src.position", "string", "01_http_svc_test.bal:27:20"),
+                new JaegerTag("src.position", "string", span3Position),
                 new JaegerTag("src.client.remote", "string", "true"),
                 new JaegerTag("src.function.name", "string", "respond"),
                 new JaegerTag("internal.span.format", "string", "proto")

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/JaegerTracesTestCase.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/JaegerTracesTestCase.java
@@ -18,6 +18,7 @@
 package io.ballerina.observe.trace.jaeger;
 
 import com.google.gson.Gson;
+import io.ballerina.observe.trace.jaeger.backend.JaegerServerProtocol;
 import io.ballerina.observe.trace.jaeger.model.JaegerProcess;
 import io.ballerina.observe.trace.jaeger.model.JaegerQueryResponse;
 import io.ballerina.observe.trace.jaeger.model.JaegerQueryResponseTypeToken;
@@ -78,16 +79,19 @@ public class JaegerTracesTestCase extends BaseTestCase {
     public Object[][] getTestJaegerMetricsData() {
         final String jaegerConfTable = "--b7a.observability.tracing.jaeger";
         return new Object[][]{
-                {"localhost", 5775, new String[0]},
-                {"127.0.0.1", 15775, new String[]{jaegerConfTable + ".reporter.hostname=127.0.0.1",
-                        jaegerConfTable + ".reporter.port=15775"}}
+                {"localhost", 5775, JaegerServerProtocol.ZIPKIN_COMPACT_THRIFT, new String[0]},
+                {"127.0.0.1", 15775, JaegerServerProtocol.ZIPKIN_COMPACT_THRIFT, new String[]{
+                        jaegerConfTable + ".reporter.hostname=127.0.0.1", jaegerConfTable + ".reporter.port=15775"}},
+                {"127.0.0.1", 6831, JaegerServerProtocol.JAEGER_COMPACT_THRIFT, new String[]{
+                        jaegerConfTable + ".reporter.hostname=127.0.0.1", jaegerConfTable + ".reporter.port=6831"}}
         };
     }
 
     @Test(dataProvider = "test-jaeger-metrics-data")
-    public void testJaegerMetrics(String host, int jaegerReportAddress, String[] additionalRuntimeArgs)
+    public void testJaegerMetrics(String host, int jaegerReportAddress, JaegerServerProtocol jaegerReportProtocol,
+                                  String[] additionalRuntimeArgs)
             throws Exception {
-        jaegerServer.startServer(host, jaegerReportAddress);
+        jaegerServer.startServer(host, jaegerReportAddress, jaegerReportProtocol);
 
         LogLeecher jaegerExtLogLeecher = new LogLeecher(JAEGER_EXTENSION_LOG_PREFIX + host + ":"
                 + jaegerReportAddress);

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/JaegerTracesTestCase.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/JaegerTracesTestCase.java
@@ -79,9 +79,7 @@ public class JaegerTracesTestCase extends BaseTestCase {
     public Object[][] getTestJaegerMetricsData() {
         final String jaegerConfTable = "--b7a.observability.tracing.jaeger";
         return new Object[][]{
-                {"localhost", 5775, JaegerServerProtocol.ZIPKIN_COMPACT_THRIFT, new String[0]},
-                {"127.0.0.1", 15775, JaegerServerProtocol.ZIPKIN_COMPACT_THRIFT, new String[]{
-                        jaegerConfTable + ".reporter.hostname=127.0.0.1", jaegerConfTable + ".reporter.port=15775"}},
+                {"localhost", 6831, JaegerServerProtocol.JAEGER_COMPACT_THRIFT, new String[0]},
                 {"127.0.0.1", 6831, JaegerServerProtocol.JAEGER_COMPACT_THRIFT, new String[]{
                         jaegerConfTable + ".reporter.hostname=127.0.0.1", jaegerConfTable + ".reporter.port=6831"}}
         };

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/JaegerTracesTestCase.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/JaegerTracesTestCase.java
@@ -82,7 +82,8 @@ public class JaegerTracesTestCase extends BaseTestCase {
         return new Object[][]{
                 {"localhost", 6831, JaegerServerProtocol.UDP_COMPACT_THRIFT, new String[0]},
                 {"127.0.0.1", 6831, JaegerServerProtocol.UDP_COMPACT_THRIFT, new String[]{
-                        jaegerConfTable + ".reporter.hostname=127.0.0.1", jaegerConfTable + ".reporter.port=6831"}}
+                        jaegerConfTable + ".reporter.agent.hostname=127.0.0.1",
+                        jaegerConfTable + ".reporter.agent.port=6831"}}
         };
     }
 

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ContainerLogReader.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ContainerLogReader.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.observe.trace.jaeger.backend;
+
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.model.Frame;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Log reader for containers.
+ */
+public class ContainerLogReader implements ResultCallback<Frame> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContainerLogReader.class);
+
+    @Override
+    public void onStart(Closeable closeable) {
+        LOGGER.info("Started reading container logs");
+    }
+
+    @Override
+    public void onNext(Frame frame) {
+        LOGGER.info(new String(frame.getPayload(), StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        LOGGER.error("Reading container logs failed", throwable);
+    }
+
+    @Override
+    public void onComplete() {
+        LOGGER.info("Completed reading container logs");
+    }
+
+    @Override
+    public void close() {   // Do Nothing
+    }
+}

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ContainerizedJaegerServer.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ContainerizedJaegerServer.java
@@ -63,7 +63,7 @@ public class ContainerizedJaegerServer implements JaegerServer {
         }
         int targetPort;
         switch (protocol) {
-            case JAEGER_COMPACT_THRIFT:
+            case UDP_COMPACT_THRIFT:
                 targetPort = 6831;
                 break;
             default:

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ContainerizedJaegerServer.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ContainerizedJaegerServer.java
@@ -63,9 +63,6 @@ public class ContainerizedJaegerServer implements JaegerServer {
         }
         int targetPort;
         switch (protocol) {
-            case ZIPKIN_COMPACT_THRIFT:
-                targetPort = 5775;
-                break;
             case JAEGER_COMPACT_THRIFT:
                 targetPort = 6831;
                 break;

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ContainerizedJaegerServer.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ContainerizedJaegerServer.java
@@ -24,6 +24,7 @@ import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientImpl;
 import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
 
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
@@ -82,7 +83,7 @@ public class ContainerizedJaegerServer implements JaegerServer {
     }
 
     @Override
-    public void cleanUp() throws Exception {
+    public void cleanUp() throws IOException {
         dockerClient.close();
         dockerClient = null;
     }

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ContainerizedJaegerServer.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ContainerizedJaegerServer.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
  */
 public class ContainerizedJaegerServer implements JaegerServer {
     private static final Logger LOGGER = Logger.getLogger(ContainerizedJaegerServer.class.getName());
-    private static final String JAEGER_IMAGE = "jaegertracing/all-in-one:1.18";
+    private static final String JAEGER_IMAGE = "jaegertracing/all-in-one:1.21.0";
 
     private DockerClient dockerClient;
     private String jaegerContainerId;

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ContainerizedJaegerServer.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ContainerizedJaegerServer.java
@@ -23,10 +23,11 @@ import com.github.dockerjava.api.model.PortBinding;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientImpl;
 import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 /**
  * Container based Jaeger Server.
@@ -34,7 +35,7 @@ import java.util.logging.Logger;
  * This is a Jaeger server implementation based on a linux Jaeger container.
  */
 public class ContainerizedJaegerServer implements JaegerServer {
-    private static final Logger LOGGER = Logger.getLogger(ContainerizedJaegerServer.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContainerizedJaegerServer.class);
     private static final String JAEGER_IMAGE = "jaegertracing/all-in-one:1.21.0";
 
     private DockerClient dockerClient;
@@ -77,6 +78,11 @@ public class ContainerizedJaegerServer implements JaegerServer {
                 .exec()
                 .getId();
         dockerClient.startContainerCmd(jaegerContainerId).exec();
+        dockerClient.logContainerCmd(jaegerContainerId)
+                .withStdOut(true)
+                .withStdErr(true)
+                .withFollowStream(true)
+                .exec(new ContainerLogReader());
         LOGGER.info("Started Jaeger container with container ID " + jaegerContainerId);
     }
 

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/JaegerServer.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/JaegerServer.java
@@ -27,9 +27,10 @@ public interface JaegerServer {
      *
      * @param interfaceIP The IP of the interface to bind to
      * @param udpBindPort The UDP publishing port to bind to
+     * @param protocol    The protocol to be used in the port
      * @throws Exception if starting the server fails
      */
-    void startServer(String interfaceIP, int udpBindPort) throws Exception;
+    void startServer(String interfaceIP, int udpBindPort, JaegerServerProtocol protocol) throws Exception;
 
     /**
      * Stop the Jaeger server which had been started.
@@ -39,7 +40,7 @@ public interface JaegerServer {
     void stopServer() throws Exception;
 
     /**
-     * Cleanup the server and all related resouces.
+     * Cleanup the server and all related resources.
      *
      * @throws Exception if cleanup fails
      */

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/JaegerServerProtocol.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/JaegerServerProtocol.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.observe.trace.jaeger.backend;
+
+/**
+ * Types of supported Jaeger protocol types.
+ */
+public enum JaegerServerProtocol {
+    ZIPKIN_COMPACT_THRIFT,
+    JAEGER_COMPACT_THRIFT
+}

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/JaegerServerProtocol.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/JaegerServerProtocol.java
@@ -21,6 +21,5 @@ package io.ballerina.observe.trace.jaeger.backend;
  * Types of supported Jaeger protocol types.
  */
 public enum JaegerServerProtocol {
-    ZIPKIN_COMPACT_THRIFT,
     JAEGER_COMPACT_THRIFT
 }

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/JaegerServerProtocol.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/JaegerServerProtocol.java
@@ -21,5 +21,5 @@ package io.ballerina.observe.trace.jaeger.backend;
  * Types of supported Jaeger protocol types.
  */
 public enum JaegerServerProtocol {
-    JAEGER_COMPACT_THRIFT
+    UDP_COMPACT_THRIFT
 }

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/JaegerServerProtocol.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/JaegerServerProtocol.java
@@ -18,7 +18,7 @@
 package io.ballerina.observe.trace.jaeger.backend;
 
 /**
- * Types of supported Jaeger protocol types.
+ * Types of supported Jaeger protocols.
  */
 public enum JaegerServerProtocol {
     UDP_COMPACT_THRIFT

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ProcessJaegerServer.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ProcessJaegerServer.java
@@ -48,13 +48,24 @@ public class ProcessJaegerServer implements JaegerServer {
     }
 
     @Override
-    public void startServer(String interfaceIP, int udpBindPort) throws IOException {
+    public void startServer(String interfaceIP, int udpBindPort, JaegerServerProtocol protocol) throws IOException {
         if (jaegerServerProcess != null || processOutputLogReader != null || processErrorLogReader != null) {
             throw new IllegalStateException("Jaeger server already started");
         }
+        String processorFlag;
+        switch (protocol) {
+            case ZIPKIN_COMPACT_THRIFT:
+                processorFlag = "--processor.zipkin-compact.server-host-port";
+                break;
+            case JAEGER_COMPACT_THRIFT:
+                processorFlag = "--processor.jaeger-compact.server-host-port";
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown Jaeger Protocol type " + protocol);
+        }
         String bindPort = interfaceIP + ":" + udpBindPort;
         jaegerServerProcess = new ProcessBuilder()
-                .command(executableFile, "--processor.zipkin-compact.server-host-port", bindPort)
+                .command(executableFile, processorFlag, bindPort)
                 .start();
         LOGGER.info("Started Jaeger process with process ID " + jaegerServerProcess.pid());
 

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ProcessJaegerServer.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ProcessJaegerServer.java
@@ -54,9 +54,6 @@ public class ProcessJaegerServer implements JaegerServer {
         }
         String processorFlag;
         switch (protocol) {
-            case ZIPKIN_COMPACT_THRIFT:
-                processorFlag = "--processor.zipkin-compact.server-host-port";
-                break;
             case JAEGER_COMPACT_THRIFT:
                 processorFlag = "--processor.jaeger-compact.server-host-port";
                 break;

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ProcessJaegerServer.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ProcessJaegerServer.java
@@ -54,7 +54,7 @@ public class ProcessJaegerServer implements JaegerServer {
         }
         String processorFlag;
         switch (protocol) {
-            case JAEGER_COMPACT_THRIFT:
+            case UDP_COMPACT_THRIFT:
                 processorFlag = "--processor.jaeger-compact.server-host-port";
                 break;
             default:
@@ -66,8 +66,8 @@ public class ProcessJaegerServer implements JaegerServer {
                 .start();
         LOGGER.info("Started Jaeger process with process ID " + jaegerServerProcess.pid());
 
-        processOutputLogReader = new ProcessLogReader("JaegerServer", jaegerServerProcess.getInputStream());
-        processErrorLogReader = new ProcessLogReader("JaegerServer", jaegerServerProcess.getErrorStream());
+        processOutputLogReader = new ProcessLogReader("ProcessJaegerServer", jaegerServerProcess.getInputStream());
+        processErrorLogReader = new ProcessLogReader("ProcessJaegerServer", jaegerServerProcess.getErrorStream());
     }
 
     @Override

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ProcessJaegerServer.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ProcessJaegerServer.java
@@ -17,10 +17,12 @@
  */
 package io.ballerina.observe.trace.jaeger.backend;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 /**
  * Executable program based Jaeger server.
@@ -28,7 +30,7 @@ import java.util.logging.Logger;
  * This starts and stops the server using scripts. The script paths need to be provided as environment variables.
  */
 public class ProcessJaegerServer implements JaegerServer {
-    private static final Logger LOGGER = Logger.getLogger(ContainerizedJaegerServer.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessJaegerServer.class);
     public static final String EXECUTABLE_ENV_VAR_KEY = "JAEGER_SERVER_EXECUTABLE";
 
     private final String executableFile;
@@ -66,8 +68,8 @@ public class ProcessJaegerServer implements JaegerServer {
                 .start();
         LOGGER.info("Started Jaeger process with process ID " + jaegerServerProcess.pid());
 
-        processOutputLogReader = new ProcessLogReader("ProcessJaegerServer", jaegerServerProcess.getInputStream());
-        processErrorLogReader = new ProcessLogReader("ProcessJaegerServer", jaegerServerProcess.getErrorStream());
+        processOutputLogReader = new ProcessLogReader(jaegerServerProcess.getInputStream());
+        processErrorLogReader = new ProcessLogReader(jaegerServerProcess.getErrorStream());
     }
 
     @Override

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ProcessLogReader.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ProcessLogReader.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.observe.trace.jaeger.backend;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Log Reader which reads and prints the output of a Process.
+ */
+public final class ProcessLogReader implements Runnable, AutoCloseable {
+    private final InputStream inputStream;
+    private final Logger logger;
+    private final Thread workerThread;
+    private boolean isRunning;
+
+    public ProcessLogReader(String name, InputStream inputStream) {
+        this.inputStream = inputStream;
+        logger = LoggerFactory.getLogger(ProcessLogReader.class.getName() + " - " + name);
+        isRunning = true;
+        workerThread = new Thread(this);
+        workerThread.start();
+    }
+
+    @Override
+    public void run() {
+        try (InputStreamReader inputStreamReader = new InputStreamReader(inputStream, Charset.defaultCharset());
+             BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
+            while (isRunning) {
+                if (bufferedReader.ready()) {
+                    String s = bufferedReader.readLine();
+                    if (s == null) {
+                        break;
+                    }
+                    logger.info(s);
+                } else {
+                    TimeUnit.SECONDS.sleep(1);
+                }
+            }
+            String s = bufferedReader.readLine();
+            if (s != null) {
+                logger.info(s);
+            }
+        } catch (Throwable t) {
+            logger.error("Problem reading process output stream", t);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        isRunning = false;
+        workerThread.join(10000);
+    }
+}

--- a/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ProcessLogReader.java
+++ b/jaeger-extension-tests/src/test/java/io/ballerina/observe/trace/jaeger/backend/ProcessLogReader.java
@@ -30,14 +30,13 @@ import java.util.concurrent.TimeUnit;
  * Log Reader which reads and prints the output of a Process.
  */
 public final class ProcessLogReader implements Runnable, AutoCloseable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessLogReader.class);
     private final InputStream inputStream;
-    private final Logger logger;
     private final Thread workerThread;
     private boolean isRunning;
 
-    public ProcessLogReader(String name, InputStream inputStream) {
+    public ProcessLogReader(InputStream inputStream) {
         this.inputStream = inputStream;
-        logger = LoggerFactory.getLogger(ProcessLogReader.class.getName() + " - " + name);
         isRunning = true;
         workerThread = new Thread(this);
         workerThread.start();
@@ -53,17 +52,17 @@ public final class ProcessLogReader implements Runnable, AutoCloseable {
                     if (s == null) {
                         break;
                     }
-                    logger.info(s);
+                    LOGGER.info(s);
                 } else {
                     TimeUnit.SECONDS.sleep(1);
                 }
             }
             String s = bufferedReader.readLine();
             if (s != null) {
-                logger.info(s);
+                LOGGER.info(s);
             }
         } catch (Throwable t) {
-            logger.error("Problem reading process output stream", t);
+            LOGGER.error("Problem reading process output stream", t);
         }
     }
 

--- a/jaeger-extension-tests/src/test/resources/bal/01_http_svc_test.bal
+++ b/jaeger-extension-tests/src/test/resources/bal/01_http_svc_test.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/io;
 import ballerina/http;
 import ballerina/observe; import ballerinax/jaeger as _;   // TODO: Remove extension module imports
 
@@ -45,4 +46,8 @@ class ObservableAdder {
     function getSum() returns int {
         return self.firstNumber + self.secondNumber;
     }
+}
+
+public function main() {
+    io:println("Starting Jaeger Resources");
 }


### PR DESCRIPTION
## Purpose
> Enable Windows builds in GitHub workflows. Along with this change, the supported latest version had been updated to Jaeger `1.21.0` and the default agent publish port had been updated to 6831 (default Jaeger Compact Thrift Agent Port) from 5775 (Deprecated Zipkin Compact Thrift Port)

Related to ballerina-platform/ballerina-lang#26247 as we need to remove deprecated ports and configs in preparation for this change

Please find the Jaeger Port information in https://www.jaegertracing.io/docs/1.21/getting-started/