### PR TITLE
Update opentelemetry versions

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -17,128 +17,20 @@
 [package]
 org = "ballerinax"
 name = "jaeger"
-version = "1.1.0"
+version = "1.1.2"
+keywords = ["Type/Driver", "Area/Developer Tools", "Vendor/Jaeger", "Observability", "tracing"]
 distribution = "2201.11.0"
 
 [platform.java21]
 graalvmCompatible = true
 
+# jaeger-extension-native bundles its OpenTelemetry SDK/exporter, grpc, netty and guava
+# dependencies as a shaded (relocated) uber-jar, so their versions can never collide with
+# whatever OTel jars other Ballerina modules (e.g. ballerina/observe) bundle on a given
+# distribution. opentelemetry-api/opentelemetry-context are intentionally not bundled here -
+# they are provided by the Ballerina runtime itself.
 [[platform.java21.dependency]]
-path = "../native/build/libs/jaeger-extension-native-1.1.0.jar"
+path = "../native/build/libs/jaeger-extension-native-1.1.2-all.jar"
 groupId = "ballerina"
 artifactId = "jaeger-extension-native"
-version = "1.1.0"
-
-[[platform.java21.dependency]]
-path = "./lib/opentelemetry-sdk-trace-1.32.0.jar"
-groupId = "io.opentelemetry"
-artifactId = "opentelemetry-sdk-trace"
-version = "1.32.0"
-
-[[platform.java21.dependency]]
-path = "./lib/opentelemetry-sdk-common-1.32.0.jar"
-groupId = "io.opentelemetry"
-artifactId = "opentelemetry-sdk-common"
-version = "1.32.0"
-
-[[platform.java21.dependency]]
-path = "./lib/opentelemetry-semconv-1.21.0-alpha.jar"
-groupId = "io.opentelemetry.semconv"
-artifactId = "opentelemetry-semconv"
-version = "1.21.0-alpha"
-
-[[platform.java21.dependency]]
-path = "./lib/opentelemetry-proto-1.7.1-alpha.jar"
-groupId = "io.opentelemetry"
-artifactId = "opentelemetry-proto"
-version = "1.7.1-alpha"
-
-[[platform.java21.dependency]]
-path = "./lib/opentelemetry-exporter-otlp-trace-1.14.0.jar"
-groupId = "io.opentelemetry"
-artifactId = "opentelemetry-exporter-otlp-trace"
-version = "1.14.0"
-
-[[platform.java21.dependency]]
-path = "./lib/opentelemetry-exporter-otlp-common-1.14.0.jar"
-groupId = "io.opentelemetry"
-artifactId = "opentelemetry-exporter-otlp-common"
-version = "1.14.0"
-
-[[platform.java21.dependency]]
-path = "./lib/opentelemetry-extension-trace-propagators-1.32.0.jar"
-groupId = "io.opentelemetry"
-artifactId = "opentelemetry-extension-trace-propagators"
-version = "1.32.0"
-
-[[platform.java21.dependency]]
-path = "./lib/guava-33.2.0-jre.jar"
-groupId = "com.google.guava"
-artifactId = "guava"
-version = "33.2.0-jre"
-
-[[platform.java21.dependency]]
-path = "./lib/failureaccess-1.0.1.jar"
-groupId = "com.google.guava"
-artifactId = "failureaccess"
-version = "1.0.1"
-
-[[platform.java21.dependency]]
-path = "./lib/grpc-api-1.54.1.jar"
-groupId = "io.grpc"
-artifactId = "grpc-api"
-version = "1.54.1"
-
-[[platform.java21.dependency]]
-path = "./lib/grpc-context-1.54.1.jar"
-groupId = "io.grpc"
-artifactId = "grpc-context"
-version = "1.54.1"
-
-[[platform.java21.dependency]]
-path = "./lib/grpc-core-1.54.1.jar"
-groupId = "io.grpc"
-artifactId = "grpc-core"
-version = "1.54.1"
-
-[[platform.java21.dependency]]
-path = "./lib/grpc-stub-1.54.1.jar"
-groupId = "io.grpc"
-artifactId = "grpc-stub"
-version = "1.54.1"
-
-[[platform.java21.dependency]]
-path = "./lib/grpc-protobuf-1.54.1.jar"
-groupId = "io.grpc"
-artifactId = "grpc-protobuf"
-version = "1.54.1"
-
-[[platform.java21.dependency]]
-path = "./lib/grpc-protobuf-lite-1.54.1.jar"
-groupId = "io.grpc"
-artifactId = "grpc-protobuf-lite"
-version = "1.54.1"
-
-[[platform.java21.dependency]]
-path = "./lib/grpc-netty-shaded-1.54.1.jar"
-groupId = "io.grpc"
-artifactId = "grpc-netty-shaded"
-version = "1.54.1"
-
-[[platform.java21.dependency]]
-path = "./lib/protobuf-java-3.25.5.jar"
-groupId = "com.google.protobuf"
-artifactId = "protobuf-java"
-version = "3.25.5"
-
-[[platform.java21.dependency]]
-path = "./lib/netty-handler-4.1.108.Final.jar"
-groupId = "io.netty"
-artifactId = "netty-handler"
-version = "4.1.108.Final"
-
-[[platform.java21.dependency]]
-path = "./lib/perfmark-api-0.23.0.jar"
-groupId = "io.perfmark"
-artifactId = "perfmark-api"
-version = "0.23.0"
+version = "1.1.2"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -19,7 +19,7 @@ org = "ballerinax"
 name = "jaeger"
 version = "1.1.2"
 keywords = ["Type/Driver", "Area/Developer Tools", "Vendor/Jaeger", "Observability", "tracing"]
-distribution = "2201.11.0"
+distribution = "2201.12.0"
 
 [platform.java21]
 graalvmCompatible = true

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.6"
+distribution-version = "2201.12.0"
 
 [[package]]
 org = "ballerina"
@@ -38,7 +38,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.17.0"
+version = "2.14.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -52,7 +52,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.2"
+version = "1.6.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.11.0"
+distribution-version = "2201.13.6"
 
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.7.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -38,7 +38,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.11.0"
+version = "2.17.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -52,7 +52,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.4.0"
+version = "1.7.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -64,7 +64,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "jaeger"
-version = "1.1.0"
+version = "1.1.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -9,6 +9,31 @@ The Jaeger Observability Extension provides an implementation for tracing and pu
 - Support for trace logging to console and file
 - Configurable reporter flush interval and buffer size
 
+### Compatibility
+
+This module's `TracerProvider` implementation must return `Tracer`/`ContextPropagators` instances
+of the exact `opentelemetry-api`/`opentelemetry-context` classes embedded in the Ballerina
+runtime's `ballerina-rt.jar` (currently 1.32.0), so those two artifacts are never bundled by this
+module - they always come from the runtime. Every other OpenTelemetry dependency this module
+bundles (`sdk-trace`, `sdk-common`, `semconv`, `exporter-otlp-trace`/`exporter-otlp-common`) is
+therefore pinned to the same 1.32.0-compatible versions, and shaded into a private package
+namespace so they can never collide with whatever (possibly different) OpenTelemetry jars other
+Ballerina modules, such as `ballerina/observe`, bundle on a given distribution.
+
+`opentelemetry-extension-trace-propagators` is the exception: it's bumped to 1.63.0 to fix
+CVE-2026-45292, since a review of its compiled classes confirmed it calls no `opentelemetry-api`
+surface beyond what 1.32.0 already provides (only `TraceFlags.getDefault`/`getSampled`,
+`Baggage.builder`, `SpanContext.createFromRemoteParent`), so it remains binary-compatible with the
+embedded runtime API. Note this only patches the copy of the vulnerable code that this module
+bundles; `opentelemetry-api`'s own copy of the vulnerable baggage-propagation code is embedded
+directly in `ballerina-rt.jar` and can only be fixed by updating `ballerina-lang` itself.
+
+If bumping any of the pinned versions in the future, watch for Gradle's default dependency
+resolution silently overriding them via transitive constraints (`opentelemetry-semconv` pulls in
+`opentelemetry-bom`, whose version constraints can bump `opentelemetry-exporter-otlp-common`,
+`opentelemetry-api`, etc. above the declared versions) - `native/build.gradle` forces every
+OpenTelemetry artifact to its intended version for exactly this reason.
+
 ## Enabling Jaeger Extension
 
 To package the Jaeger extension into the Jar, follow the following steps.

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -22,9 +22,6 @@ configurations {
     nativeJar {
         transitive false
     }
-    externalJars {
-        transitive false
-    }
     distribution {
         canBeConsumed true
         canBeResolved false
@@ -33,28 +30,6 @@ configurations {
 
 dependencies {
     nativeJar project(':jaeger-extension-native')
-
-    externalJars "io.opentelemetry:opentelemetry-api:${openTelemetryVersion}"
-    externalJars "io.opentelemetry:opentelemetry-context:${openTelemetryVersion}"
-    externalJars "io.opentelemetry:opentelemetry-sdk-trace:${openTelemetryVersion}"
-    externalJars "io.opentelemetry:opentelemetry-sdk-common:${openTelemetryVersion}"
-    externalJars "io.opentelemetry.semconv:opentelemetry-semconv:${openTelemetrySemconvVersion}"
-    externalJars "io.opentelemetry:opentelemetry-proto:${openTelemetryProtoVersion}"
-    externalJars "io.opentelemetry:opentelemetry-exporter-otlp-trace:${openTelemetryExporterVersion}"
-    externalJars "io.opentelemetry:opentelemetry-exporter-otlp-common:${openTelemetryExporterVersion}"
-    externalJars "io.opentelemetry:opentelemetry-extension-trace-propagators:${openTelemetryVersion}"
-    externalJars "com.google.guava:guava:${guavaVersion}"
-    externalJars "com.google.guava:failureaccess:${failureAccessVersion}"
-    externalJars "io.grpc:grpc-api:${grpcVersion}"
-    externalJars "io.grpc:grpc-context:${grpcVersion}"
-    externalJars "io.grpc:grpc-core:${grpcVersion}"
-    externalJars "io.grpc:grpc-stub:${grpcVersion}"
-    externalJars "io.grpc:grpc-protobuf:${grpcVersion}"
-    externalJars "io.grpc:grpc-protobuf-lite:${grpcVersion}"
-    externalJars "io.grpc:grpc-netty-shaded:${grpcVersion}"
-    externalJars "com.google.protobuf:protobuf-java:${protobufVersion}"
-    externalJars "io.netty:netty-handler:${nettyVersion}"
-    externalJars "io.perfmark:perfmark-api:${perfmarkVersion}"
 }
 
 clean {
@@ -67,11 +42,6 @@ jar {
     manifest {
         attributes('Implementation-Title': project.name, 'Implementation-Version': project.version)
     }
-}
-
-task copyExternalJarsToLib(type: Copy) {
-    into "${project.projectDir}/lib"
-    from configurations.externalJars
 }
 
 def packageOrg = "ballerinax"
@@ -103,31 +73,8 @@ def stripBallerinaExtensionVersion(String extVersion) {
 
 task updateTomlVersions {
     doLast {
-        def openTelemetryVersion = project.openTelemetryVersion
-        def openTelemetrySDKVersion = project.openTelemetrySDKVersion
-        def openTelemetryExporterVersion = project.openTelemetryExporterVersion
-        def openTelemetrySemconvVersion = project.openTelemetrySemconvVersion
-        def openTelemetryProtoVersion = project.openTelemetryProtoVersion
-        def guavaVersion = project.guavaVersion
-        def failureAccessVersion = project.failureAccessVersion
-        def grpcVersion = project.grpcVersion
-        def nettyVersion = project.nettyVersion
-        def protobufVersion = project.protobufVersion
-        def perfmarkVersion = project.perfmarkVersion
-
         def newConfig = ballerinaTomlFilePlaceHolder.text.replace("@project.version@", project.version)
         newConfig = newConfig.replace("@toml.version@", tomlVersion)
-        newConfig = newConfig.replace("@opentelemetry.version@", openTelemetryVersion)
-        newConfig = newConfig.replace("@opentelemetrySDK.version@", openTelemetrySDKVersion)
-        newConfig = newConfig.replace("@opentelemetryExporter.version@", openTelemetryExporterVersion)
-        newConfig = newConfig.replace("@opentelemetrySemconv.version@", openTelemetrySemconvVersion)
-        newConfig = newConfig.replace("@opentelemetryProto.version@", openTelemetryProtoVersion)
-        newConfig = newConfig.replace("@guava.version@", guavaVersion)
-        newConfig = newConfig.replace("@failureAccess.version@", failureAccessVersion)
-        newConfig = newConfig.replace("@grpc.version@", grpcVersion)
-        newConfig = newConfig.replace("@netty.version@", nettyVersion)
-        newConfig = newConfig.replace("@protobuf.version@", protobufVersion)
-        newConfig = newConfig.replace("@perfmark.version@", perfmarkVersion)
         ballerinaTomlFile.text = newConfig
     }
 }
@@ -137,8 +84,7 @@ task updateTomlVersions {
 task ballerinaBuild {
     dependsOn updateTomlVersions
     dependsOn configurations.nativeJar
-    dependsOn configurations.externalJars
-    dependsOn copyExternalJarsToLib
+    dependsOn ':jaeger-extension-native:shadowJar'
     dependsOn compileJava
     dependsOn compileTestJava
     dependsOn jar

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -19,7 +19,7 @@ org = "ballerinax"
 name = "jaeger"
 version = "@toml.version@"
 keywords = ["Type/Driver", "Area/Developer Tools", "Vendor/Jaeger", "Observability", "tracing"]
-distribution = "2201.11.0"
+distribution = "2201.12.0"
 
 [platform.java21]
 graalvmCompatible = true

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -24,122 +24,13 @@ distribution = "2201.11.0"
 [platform.java21]
 graalvmCompatible = true
 
+# jaeger-extension-native bundles its OpenTelemetry SDK/exporter, grpc, netty and guava
+# dependencies as a shaded (relocated) uber-jar, so their versions can never collide with
+# whatever OTel jars other Ballerina modules (e.g. ballerina/observe) bundle on a given
+# distribution. opentelemetry-api/opentelemetry-context are intentionally not bundled here -
+# they are provided by the Ballerina runtime itself.
 [[platform.java21.dependency]]
-path = "../native/build/libs/jaeger-extension-native-@project.version@.jar"
+path = "../native/build/libs/jaeger-extension-native-@project.version@-all.jar"
 groupId = "ballerina"
 artifactId = "jaeger-extension-native"
 version = "@project.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/opentelemetry-sdk-trace-@opentelemetrySDK.version@.jar"
-groupId = "io.opentelemetry"
-artifactId = "opentelemetry-sdk-trace"
-version = "@opentelemetrySDK.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/opentelemetry-sdk-common-@opentelemetrySDK.version@.jar"
-groupId = "io.opentelemetry"
-artifactId = "opentelemetry-sdk-common"
-version = "@opentelemetrySDK.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/opentelemetry-semconv-@opentelemetrySemconv.version@.jar"
-groupId = "io.opentelemetry.semconv"
-artifactId = "opentelemetry-semconv"
-version = "@opentelemetrySemconv.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/opentelemetry-proto-@opentelemetryProto.version@.jar"
-groupId = "io.opentelemetry"
-artifactId = "opentelemetry-proto"
-version = "@opentelemetryProto.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/opentelemetry-exporter-otlp-trace-@opentelemetryExporter.version@.jar"
-groupId = "io.opentelemetry"
-artifactId = "opentelemetry-exporter-otlp-trace"
-version = "@opentelemetryExporter.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/opentelemetry-exporter-otlp-common-@opentelemetryExporter.version@.jar"
-groupId = "io.opentelemetry"
-artifactId = "opentelemetry-exporter-otlp-common"
-version = "@opentelemetryExporter.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/opentelemetry-extension-trace-propagators-@opentelemetry.version@.jar"
-groupId = "io.opentelemetry"
-artifactId = "opentelemetry-extension-trace-propagators"
-version = "@opentelemetry.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/guava-@guava.version@.jar"
-groupId = "com.google.guava"
-artifactId = "guava"
-version = "@guava.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/failureaccess-@failureAccess.version@.jar"
-groupId = "com.google.guava"
-artifactId = "failureaccess"
-version = "@failureAccess.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/grpc-api-@grpc.version@.jar"
-groupId = "io.grpc"
-artifactId = "grpc-api"
-version = "@grpc.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/grpc-context-@grpc.version@.jar"
-groupId = "io.grpc"
-artifactId = "grpc-context"
-version = "@grpc.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/grpc-core-@grpc.version@.jar"
-groupId = "io.grpc"
-artifactId = "grpc-core"
-version = "@grpc.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/grpc-stub-@grpc.version@.jar"
-groupId = "io.grpc"
-artifactId = "grpc-stub"
-version = "@grpc.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/grpc-protobuf-@grpc.version@.jar"
-groupId = "io.grpc"
-artifactId = "grpc-protobuf"
-version = "@grpc.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/grpc-protobuf-lite-@grpc.version@.jar"
-groupId = "io.grpc"
-artifactId = "grpc-protobuf-lite"
-version = "@grpc.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/grpc-netty-shaded-@grpc.version@.jar"
-groupId = "io.grpc"
-artifactId = "grpc-netty-shaded"
-version = "@grpc.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/protobuf-java-@protobuf.version@.jar"
-groupId = "com.google.protobuf"
-artifactId = "protobuf-java"
-version = "@protobuf.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/netty-handler-@netty.version@.jar"
-groupId = "io.netty"
-artifactId = "netty-handler"
-version = "@netty.version@"
-
-[[platform.java21.dependency]]
-path = "./lib/perfmark-api-@perfmark.version@.jar"
-groupId = "io.perfmark"
-artifactId = "perfmark-api"
-version = "@perfmark.version@"

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 plugins {
     id 'checkstyle'
     id "com.github.spotbugs" version "${githubSpotbugsVersion}"
-    id "com.github.johnrengelman.shadow" version "${githubJohnrengelmanShadowVersion}"
+    id "com.gradleup.shadow" version "${githubJohnrengelmanShadowVersion}"
     id "de.undercouch.download" version "${underCouchDownloadVersion}"
     id "net.researchgate.release" version "${researchgateReleaseVersion}"
     id "jacoco"

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 group=org.ballerinalang
-version=1.1.1-SNAPSHOT
+version=1.1.2
 ballerinaLangVersion=2201.12.0
 org.gradle.caching=true
 org.gradle.parallel=true
@@ -21,16 +21,24 @@ org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.workers.max=3
 
 githubSpotbugsVersion=6.0.18
-githubJohnrengelmanShadowVersion=8.1.1
+githubJohnrengelmanShadowVersion=8.3.11
 underCouchDownloadVersion=5.4.0
 researchgateReleaseVersion=2.8.0
 
 # Native Dependency Versions
+# openTelemetryVersion/openTelemetrySDKVersion/openTelemetrySemconvVersion/openTelemetryExporterVersion
+# are pinned to match the opentelemetry-api/opentelemetry-context version embedded in
+# ballerina-rt.jar (currently 1.32.0), since the TracerProvider SPI requires this module's SDK to
+# stay binary-compatible with whatever API the Ballerina runtime provides - it cannot bundle its
+# own api/context. Only openTelemetryPropagatorsVersion is bumped: opentelemetry-extension-trace-
+# propagators is the one CVE-2026-45292-affected artifact this module actually bundles, and its
+# 1.63.0 build was verified to call no API surface beyond what 1.32.0 already provides.
 openTelemetryVersion=1.32.0
 openTelemetryExporterVersion=1.14.0
 openTelemetrySDKVersion=1.32.0
 openTelemetrySemconvVersion=1.21.0-alpha
 openTelemetryProtoVersion=1.7.1-alpha
+openTelemetryPropagatorsVersion=1.63.0
 guavaVersion=33.2.0-jre
 failureAccessVersion=1.0.1
 grpcVersion=1.75.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -17,19 +17,41 @@
 plugins {
     id 'java-library'
     id 'jacoco'
+    id 'com.gradleup.shadow'
 }
 
 description = 'Ballerina - Jaeger Extension - Native Module'
 
+// opentelemetry-semconv pulls in opentelemetry-bom, whose version constraints otherwise bump
+// opentelemetry-exporter-otlp-common/opentelemetry-api/opentelemetry-context past the versions
+// declared below (silently pairing otlp-trace:1.14.0 with an incompatible otlp-common:1.29.0,
+// for example). Force every OpenTelemetry artifact to the exact version this module intends.
+configurations.all {
+    resolutionStrategy {
+        force "io.opentelemetry:opentelemetry-api:${openTelemetryVersion}"
+        force "io.opentelemetry:opentelemetry-context:${openTelemetryVersion}"
+        force "io.opentelemetry:opentelemetry-sdk-trace:${openTelemetrySDKVersion}"
+        force "io.opentelemetry:opentelemetry-sdk-common:${openTelemetrySDKVersion}"
+        force "io.opentelemetry.semconv:opentelemetry-semconv:${openTelemetrySemconvVersion}"
+        force "io.opentelemetry:opentelemetry-proto:${openTelemetryProtoVersion}"
+        force "io.opentelemetry:opentelemetry-exporter-otlp-trace:${openTelemetryExporterVersion}"
+        force "io.opentelemetry:opentelemetry-exporter-otlp-common:${openTelemetryExporterVersion}"
+        force "io.opentelemetry:opentelemetry-extension-trace-propagators:${openTelemetryPropagatorsVersion}"
+    }
+}
+
 dependencies {
-    implementation "org.ballerinalang:ballerina-runtime:${ballerinaLangVersion}"
-    implementation "io.opentelemetry:opentelemetry-context:${openTelemetryVersion}"
+    compileOnly "org.ballerinalang:ballerina-runtime:${ballerinaLangVersion}"
+    compileOnly "io.opentelemetry:opentelemetry-context:${openTelemetryVersion}"
     implementation "io.opentelemetry:opentelemetry-sdk-trace:${openTelemetrySDKVersion}"
     implementation "io.opentelemetry:opentelemetry-sdk-common:${openTelemetrySDKVersion}"
     implementation "io.opentelemetry.semconv:opentelemetry-semconv:${openTelemetrySemconvVersion}"
+    implementation "io.opentelemetry:opentelemetry-proto:${openTelemetryProtoVersion}"
     implementation "io.opentelemetry:opentelemetry-exporter-otlp-trace:${openTelemetryExporterVersion}"
-    implementation "io.opentelemetry:opentelemetry-extension-trace-propagators:${openTelemetryVersion}"
-    implementation "io.opentelemetry:opentelemetry-sdk-extension-jaeger-remote-sampler:${openTelemetrySDKVersion}"
+    implementation "io.opentelemetry:opentelemetry-exporter-otlp-common:${openTelemetryExporterVersion}"
+    // Only this dependency is bumped past the version embedded in ballerina-rt.jar - see the note
+    // above openTelemetryPropagatorsVersion in gradle.properties.
+    implementation "io.opentelemetry:opentelemetry-extension-trace-propagators:${openTelemetryPropagatorsVersion}"
 
     implementation("com.google.guava:guava:${guavaVersion}") {
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
@@ -63,6 +85,8 @@ dependencies {
     implementation("io.netty:netty-handler:${nettyVersion}")
     implementation "io.perfmark:perfmark-api:${perfmarkVersion}"
 
+    testImplementation "org.ballerinalang:ballerina-runtime:${ballerinaLangVersion}"
+    testImplementation "io.opentelemetry:opentelemetry-context:${openTelemetryVersion}"
     testImplementation "org.testng:testng:${testngVersion}"
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
     testImplementation "io.opentelemetry:opentelemetry-sdk-testing:${openTelemetrySDKVersion}"
@@ -114,13 +138,52 @@ jar {
     }
 }
 
+// Relocates jaeger's OpenTelemetry SDK/exporter/grpc/protobuf/netty/guava dependencies into a
+// jaeger-private package namespace, so their versions can never collide with whatever OTel jars
+// other Ballerina modules (e.g. ballerina/observe) bundle on a given distribution - confirmed
+// necessary empirically: without shading, ballerina/observe's bundled opentelemetry-sdk-common
+// 1.0.0 collides with this module's 1.32.0 copy, and the runtime can end up loading the wrong one
+// (NoClassDefFoundError on classes like ThrottlingLogger that only exist in the newer jar).
+// opentelemetry-api/opentelemetry-context are deliberately left unshaded and excluded: they are
+// embedded directly inside ballerina-rt.jar, and the TracerProvider SPI contract requires the
+// exact same (runtime-provided) Tracer/ContextPropagators classes to cross that boundary.
+shadowJar {
+    archiveClassifier.set('all')
+    configurations = [project.configurations.runtimeClasspath]
+
+    dependencies {
+        exclude(dependency('io.opentelemetry:opentelemetry-api'))
+        exclude(dependency('io.opentelemetry:opentelemetry-context'))
+    }
+
+    relocate 'io.opentelemetry.sdk', 'io.ballerina.observe.trace.jaeger.shaded.io.opentelemetry.sdk'
+    relocate 'io.opentelemetry.exporter', 'io.ballerina.observe.trace.jaeger.shaded.io.opentelemetry.exporter'
+    relocate 'io.opentelemetry.semconv', 'io.ballerina.observe.trace.jaeger.shaded.io.opentelemetry.semconv'
+    relocate 'io.opentelemetry.extension', 'io.ballerina.observe.trace.jaeger.shaded.io.opentelemetry.extension'
+    relocate 'io.opentelemetry.common', 'io.ballerina.observe.trace.jaeger.shaded.io.opentelemetry.common'
+    relocate 'io.opentelemetry.proto', 'io.ballerina.observe.trace.jaeger.shaded.io.opentelemetry.proto'
+    relocate 'io.grpc', 'io.ballerina.observe.trace.jaeger.shaded.io.grpc'
+    relocate 'io.netty', 'io.ballerina.observe.trace.jaeger.shaded.io.netty'
+    relocate 'com.google.protobuf', 'io.ballerina.observe.trace.jaeger.shaded.com.google.protobuf'
+    relocate 'com.google.common', 'io.ballerina.observe.trace.jaeger.shaded.com.google.common'
+    relocate 'com.google.gson', 'io.ballerina.observe.trace.jaeger.shaded.com.google.gson'
+    relocate 'io.perfmark', 'io.ballerina.observe.trace.jaeger.shaded.io.perfmark'
+
+    exclude 'module-info.class'
+    mergeServiceFiles()
+
+    manifest {
+        attributes('Implementation-Title': project.name, 'Implementation-Version': project.version)
+    }
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
             groupId project.group
             artifactId "jaeger-extension-native"
             version = project.version
-            artifact jar
+            artifact shadowJar
         }
     }
 


### PR DESCRIPTION
## Purpose
$subject

Fixes `CVE-2026-45292` (OpenTelemetry Java SDK unbounded memory allocation in W3C baggage propagation) in this module, while keeping it working across both old and new Ballerina distributions.

## Background

This module's `TracerProvider` implementation returns `Tracer`/`ContextPropagators` instances that must be the *exact* `opentelemetry-api`/`opentelemetry-context` classes embedded in `ballerina-rt.jar` (the `TracerProvider` SPI contract requires this) — so those two artifacts can never be bundled here; they always come from the runtime. Currently that's `1.32.0`.

Of this module's own bundled OpenTelemetry dependencies, only `opentelemetry-extension-trace-propagators` is actually affected by the CVE. Bumping the rest (`sdk-trace`, `sdk-common`, `exporter-otlp-trace/-common`) turned out to be both unnecessary and actively harmful: newer SDK versions call `opentelemetry-api` methods (e.g. `TraceFlags.builder()`) that don't exist in the `1.32.0` API embedded in `ballerina-rt.jar`, causing `NoSuchMethodError` on real Ballerina distributions the moment a span is created.

## Changes

- **Bumped only `opentelemetry-extension-trace-propagators`** to `1.63.0` (fixed version). Verified by decompiling its classes that it calls no `opentelemetry-api` surface beyond what `1.32.0` already provides (`TraceFlags.getDefault/getSampled`, `Baggage.builder`, `SpanContext.createFromRemoteParent`) — so it stays binary-compatible with the runtime-embedded API.
- **Left everything else pinned** to the original, proven-compatible versions (`sdk-trace`/`sdk-common` `1.32.0`, `semconv` `1.21.0-alpha`, `exporter-otlp-trace`/`exporter-otlp-common` `1.14.0`).
- **Shaded (relocated) the module's OpenTelemetry/grpc/protobuf/netty/guava dependencies** into a private package namespace. This is necessary, not cosmetic: `ballerina/observe` bundles its own (even older, `1.0.0`) copies of `sdk-trace`/`sdk-common`/`semconv`, and without shading the runtime classpath merge can silently load the wrong version's class for a given name, causing `NoClassDefFoundError`s that only show up once a distribution ships a different `observe` version. This was confirmed empirically by temporarily removing shading and reproducing exactly this failure.
- **Forced explicit dependency versions** (`resolutionStrategy.force`) in `native/build.gradle`: `opentelemetry-semconv` transitively pulls in `opentelemetry-bom`, whose version constraints otherwise silently bump `opentelemetry-exporter-otlp-common` past the version paired with `opentelemetry-exporter-otlp-trace`, producing an `IncompatibleClassChangeError` at runtime.
- Switched the Shadow Gradle plugin from the abandoned `com.github.johnrengelman.shadow:8.1.1` to the maintained fork `com.gradleup.shadow:8.3.11` (the old plugin's bundled ASM can't read Java 21 class files), which also required bumping the Gradle wrapper to `8.10.2`.

## Testing

- All 34 native unit tests pass; checkstyle/spotbugs clean.
- Verified end-to-end (real HTTP traffic through a sample service with jaeger + prometheus enabled) on two distributions:
  - Stock Ballerina `2201.13.x` (unpatched `ballerina-rt.jar`, embeds `opentelemetry-api:1.32.0`)
  - A `ballerina-lang` build with its own embedded OpenTelemetry API patched for this same CVE

## Known limitation

`opentelemetry-api`'s own copy of the vulnerable baggage-propagation code is embedded directly in `ballerina-rt.jar` and is outside this module's control — fixing that requires a `ballerina-lang` update, not a `jaeger` dependency bump.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
- Unit tests
  > Code coverage information
- Integration tests
  > Details about the test cases and coverage

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
- Ran FindSecurityBugs plugin and verified report? yes/no
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the Jaeger module and related Ballerina dependency versions to 1.1.2.
- Consolidated OpenTelemetry and supporting libraries into a shaded native uber-jar, reducing individually managed platform dependencies.
- Updated Gradle Shadow plugin and wrapper versions.
- Added dependency version enforcement and relocation rules to improve runtime compatibility and prevent library conflicts.
- Documented compatibility requirements for OpenTelemetry runtime classes and dependency resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->